### PR TITLE
Fixing volumetric masks generated from bounding boxes

### DIFF
--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -90,11 +90,11 @@ def boxes2nii():
 
         prediction_meta = {}
         for instance_id, (pbox, pscore, plabel) in enumerate(zip(boxes, scores, labels), start=1):
-            mask_slicing = [slice(int(pbox[0]) + 1, int(pbox[2])),
-                            slice(int(pbox[1]) + 1, int(pbox[3])),
+            mask_slicing = [slice(int(pbox[0]), int(pbox[2]) + 1),
+                            slice(int(pbox[1]), int(pbox[3]) + 1),
                             ]
             if instance_mask.ndim == 3:
-                mask_slicing.append(slice(int(pbox[4]) + 1, int(pbox[5])))
+                mask_slicing.append(slice(int(pbox[4]), int(pbox[5]) + 1))
             instance_mask[tuple(mask_slicing)] = instance_id
 
             prediction_meta[int(instance_id)] = {


### PR DESCRIPTION
Hi, I've been working on results visualization and I found a bug regarding the boundaries of volumetric masks generated from the bounding boxes. It looks like the slices are being shifted by one. Please consider the following bounding box coordinates in a single axis:
- x1 = 10.2, x2 = 10.8 -> from casting to int you get slice(11, 10, None) object -> no data will be visualized (one slice should be added)
- x1 = 10.2, x2 = 11.8 -> from casting to int you get slice(11, 11, None) object -> still no data (two slices should be added)

I fixed the indices and double-checked the results in ITK-SNAP. I'm assuming that coordinates are inclusive based on your explanation from [#114](https://github.com/MIC-DKFZ/nnDetection/issues/114).
