### PR TITLE
repare docker images error

### DIFF
--- a/nndet/core/boxes/anchors.py
+++ b/nndet/core/boxes/anchors.py
@@ -361,7 +361,8 @@ class AnchorGenerator3D(AnchorGenerator2D):
             shifts_y = torch.arange(0, size1, dtype=dtype, device=device) * stride1
             shifts_z = torch.arange(0, size2, dtype=dtype, device=device) * stride2
 
-            shift_x, shift_y, shift_z = torch.meshgrid(shifts_x, shifts_y, shifts_z, indexing="ij")
+            #shift_x, shift_y, shift_z = torch.meshgrid(shifts_x, shifts_y, shifts_z, indexing="ij")
+            shift_x, shift_y, shift_z = torch.meshgrid(shifts_x, shifts_y, shifts_z)
             shift_x = shift_x.reshape(-1)
             shift_y = shift_y.reshape(-1)
             shift_z = shift_z.reshape(-1)

--- a/nndet/core/retina.py
+++ b/nndet/core/retina.py
@@ -364,7 +364,8 @@ class BaseRetinaNet(AbstractModel):
             keep_idxs = probs > self.score_thresh
             probs, idx = probs[keep_idxs], idx[keep_idxs]
 
-        anchor_idxs = torch.div(idx, self.num_foreground_classes, rounding_mode="floor")
+        #anchor_idxs = torch.div(idx, self.num_foreground_classes, rounding_mode="floor")
+        anchor_idxs = torch.floor_divide(idx, self.num_foreground_classes)
         labels = idx % self.num_foreground_classes
         boxes = boxes[anchor_idxs]
 


### PR DESCRIPTION
TypeError: meshgrid() got an unexpected keyword argument 'indexing'
File "/opt/code/nndet/nndet/core/boxes/anchors.py", line 364, change to
shift_x, shift_y, shift_z = torch.meshgrid(shifts_x, shifts_y, shifts_z)
File "/opt/code/nndet/nndet/core/retina.py", line 367, in postprocess_detections_single_image
anchor_idxs = torch.div(idx, self.num_foreground_classes, rounding_mode="floor")
TypeError: div() got an unexpected keyword argument 'rounding_mode'
File "/opt/code/nndet/nndet/core/retina.py", line 367,change to
anchor_idxs = torch.floor_divide(idx, self.num_foreground_classes)