### PR TITLE
Safer filtration of cases with _seg suffix

### DIFF
--- a/nndet/io/utils.py
+++ b/nndet/io/utils.py
@@ -47,7 +47,7 @@ def get_np_paths_from_dir(directory: Pathlike) -> List[str]:
         if not case_paths:
             logger.error(f"Did not find any npz files.")
             raise RuntimeError(f"Did not find any npz files. Folder: {directory}")
-    case_paths = [f for f in case_paths if "_seg" not in f]
+    case_paths = [f for f in case_paths if not f.endswith("_seg")]
     case_paths.sort()
     return case_paths
 


### PR DESCRIPTION
Quick fix for situation when "_seg" is part of the case path. 

I've resolved my issue mentioned in https://github.com/MIC-DKFZ/nnDetection/issues/134 and renamed the experiment to an unfortunate name of "_trim_seg_to_brain". All studies were filtered out on the start of the training.