### PR TITLE
LUNA16 prepare script - indexing pandas DF with a set is deprecated -…

### DIFF
--- a/projects/Task016_Luna/scripts/prepare.py
+++ b/projects/Task016_Luna/scripts/prepare.py
@@ -38,7 +38,7 @@ def create_masks(source: Path, target: Path, df: pd.DataFrame, num_processes: in
         c = []
         r = []
         try:
-            series_df = df.loc[{f.name.rsplit('.', 1)[0]}]
+            series_df = df.loc[[f.name.rsplit('.', 1)[0]]]
         except KeyError:
             pass
         else:


### PR DESCRIPTION
Since https://github.com/pandas-dev/pandas/issues/42825 - `.loc` indexing with a set is deprecated and fails.

This PR just fixes that for all pandas versions by using a list instead