### PR TITLE
removed constraint on nevergrad, since the old one isn't compatible with numpy > 1.20.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ scikit-learn
 scikit-image>=0.14
 pandas>=0.8.1
 PyYAML>=5.1, !=5.4.*
-nevergrad<=0.4.2
+nevergrad
 dicom2nifti
 medpy
 SimpleITK<2.1.0


### PR DESCRIPTION
nevergrad was using `numpy.int` which got removed.

Since the constraint was introduced in https://github.com/MIC-DKFZ/nnDetection/issues/64 - I think it's ok to remove it.