### PR TITLE
Fix of issue 248

### DIFF
--- a/nndet/io/load.py
+++ b/nndet/io/load.py
@@ -180,6 +180,9 @@ def unpack_dataset(folder: Pathlike,
     """
     logger.info("Unpacking dataset")
     npz_files = subfiles(Path(folder), identifier="*.npz", join=True)
+    if not npz_files:
+        logger.warning(f'No paths found in {Path(folder)} matching *.npz')
+        return
     with Pool(processes) as p:
         p.starmap(npz2npy, zip(npz_files, repeat(delete_npz)))
 

--- a/nndet/io/paths.py
+++ b/nndet/io/paths.py
@@ -34,7 +34,7 @@ def subfiles(dir_path: Path, identifier: str, join: bool) -> List[str]:
     Returns:
         List[str]: found paths/file names
     """
-    paths = list(map(str, list(Path(dir_path).glob(identifier))))
+    paths = list(map(str, list(Path(os.path.expandvars(dir_path)).glob(identifier))))
     if not join:
         paths = [p.rsplit(os.path.sep, 1)[-1] for p in paths]
     return paths


### PR DESCRIPTION
Environment variables are now expanded when used as a dir_path argument in the subfiles function. I also added a warning in the unpack_dataset function to notify the user when no .npz files are found in the folder, not sure if this is warranted. 